### PR TITLE
fix(ci): Sanitize PR title by using ENV variable

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -18,6 +18,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     name: 'conventional-title:required'
     runs-on: ubuntu-latest
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
     steps:
       # Conventional commit patterns:
       #   verb: description
@@ -28,11 +30,11 @@ jobs:
       # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
       # !: Indicates that the PR contains a breaking change.
       - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR Title does not match conventions"
-              echo "PR Title: ${{ github.event.pull_request.title }}"
+              echo "PR Title: $TITLE"
               exit 1
           fi
   check_commits:


### PR DESCRIPTION
We need to sanitize the PR title by leveraging an environment variable as an intermediate step to prevent potential script injection attacks. This additional measure enhances the security of the workflow.